### PR TITLE
CSI-78 Add changes to header and flesh out readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,28 @@
 # Zendesk theme #
-Theme for https://support.coursehero.com/
 
-Installation
--------------
+GitHub Integration Theme for https://support.coursehero.com/
 
 Basic Usage
 -------------
+To make edits to the zendesk theme, start by previewing your changes in the sandbox and getting them approved before making them live. 
+
+Access LIVE site theme page here: [https://coursehero.zendesk.com/theming/workbench](https://coursehero.zendesk.com/theming/workbench)
+
+Access sandbox site theme page here: [https://coursehero1581700722.zendesk.com/theming/workbench](https://coursehero1581700722.zendesk.com/theming/workbench)
+Sandbox site url: [https://coursehero1581700722.zendesk.com/hc/en-us](https://coursehero1581700722.zendesk.com/hc/en-us)
+
+[To update your Guide theme from GitHub (click for zendesk wiki)](https://support.zendesk.com/hc/en-us/articles/360020203354): 
+
+1. Pull down the latest version of master, check out a new branch, and make the necessary changes to your theme and increment the theme version number in the manifest.json file as well.
+
+1. To test your theme, push your changes to Github. On the sandbox theme page, click on 'Add new theme' -> 'Fetch from Github'.
+ * Repository URL: [https://github.com/coursehero/zendesk-theme](https://github.com/coursehero/zendesk-theme)
+ * Branch name: whateverYourBranchNameIs
+
+1. Make your feature branch theme live. 
+1. Click the theme options menu, then select 'Update from GitHub'. Click 'Update'.
+![Options Menu](https://zen-marketing-documentation.s3.amazonaws.com/docs/en/github_theme_options_menu.png)
+
+1. Open a PR on Github to get your changes approved and merge your code to master.
+1. Visit the [Live site theme page](https://coursehero.zendesk.com/theming/workbench) and update the theme from Github. 
+ * If necessary, you can Fetch from Github again and make a new copy and then set that updated version as live.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Custom Theme",
   "author": "Zendesk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -11,65 +11,18 @@
   </a>
   <ul class="ch_nav_group isBrowseMenu">
   	<li>
-  		<a class="ch_nav_action isHamburgerMenu" href="#">
+  		<a class="ch_nav_action isHamburgerMenu" href="#" id="ch_hamburgerMenu">
         <span class="bar"></span>
         <span></span>
       </a>
-  		<div class="ch_subNav_panel">
+  		<div class="ch_subNav_panel" id="ch_subNav_panel">
   			<ul class="ch_mobileNav_group">
-  				<li class="hasChildren">
-          <a href="https://www.coursehero.com/study-materials/" title="Study Resources">Find Study Resources</a>
-          <ul class="isHidden">
-        		<li class="oneLevelUpAction">
-              <a href="#"><i class="fa fa-angle-left"></i> Main Menu</a>
-            </li>
-        		<li>
-              <a href="https://www.coursehero.com/study-materials/" rel="" title="by School">by School</a>
-            </li>
-          	<li>
-              <a href="https://www.coursehero.com/lit/" rel="" title="by Literature Guides">by Literature Guides</a>
-            </li>
-        		<li>
-              <a href="https://www.coursehero.com/subjects/" rel="" title="by Subject">by Subject</a>
-            </li>
-      		</ul>
-  				<a href="https://www.coursehero.com/tutors/homework-help/" title="Tutoring Help">Get instant Tutoring Help</a>
-  				<ul class="isHidden">
-            <li class="oneLevelUpAction">
-              <a href="#"><i class="fa fa-angle-left"></i> Main Menu</a>
-            </li>
-            <li>
-              <a href="https://www.coursehero.com/free-access/" rel="" title="Earn Free Access">
-                Earn Free Access
-              </a>
-            </li>
-            <li>
-              <a href="https://www.coursehero.com/upload/" rel="nofollow" title="Upload Documents">
-                Upload Documents
-              </a>
-            </li>
-            <li>
-              <a href="https://www.coursehero.com/referrals/" rel="nofollow" title="Refer your Friends">
-                Refer your Friends
-              </a>
-            </li>
-            <li>
-              <a href="https://www.coursehero.com/earn-money/" rel="" title="Earn Money">
-                Earn Money
-              </a>
-            </li>
-            <li>
-              <a href="https://www.coursehero.com/scholarships/" rel="" title="Apply for Scholarship">
-                Apply for Scholarship
-              </a>
-            </li>
-            <li>
-              <a href="https://www.coursehero.com/qa/expert/landing.php" rel="" title="Become a Tutor">
-                Become a Tutor
-              </a>
-            </li>
-        	</ul>
-				</li>
+        <li class="hasChildren">
+          <a href="https://www.coursehero.com/study-materials/" class="" title="Study Resources">Study Resources</a>
+  				<a href="https://www.coursehero.com/tutors/homework-help/" title="Expert Tutors">Expert Tutors</a>
+          <a href="https://www.coursehero.com/free-access/" class="" title="Contributing">Contributing</a>
+          <a href="https://www.coursehero.com/educators/" class="" title="For Educators" id="ch_areYouTeacher_button">For Educators</a>
+        </li>
   			<li class="ch_mobileAppLinks">
           <a href="https://itunes.apple.com/app/apple-store/id922208952?pt=108036802&amp;ct=nav_menu&amp;mt=8" class="ch-external-link" target="_blank" rel="nofollow">
             <img alt="app store button" class="ch_mobilePromotion_button" src="https://www.coursehero.com/assets/img/header/appstore.png" height="30">
@@ -196,6 +149,11 @@
   })
 </script-->
 <script>
+  $("#ch_hamburgerMenu").click(() => {
+    $("#ch_hamburgerMenu").toggleClass("dropdownIsActive")
+    $("#ch_subNav_panel").toggleClass("dropdownIsActive")
+  })
+
   jQuery("#byBook").hover(
   	function() {
   		jQuery("#byBookCategories").addClass("isDisplayed");


### PR DESCRIPTION
@rdavidreid, @abrizvi for review. 

Adding back the updates for our zendesk theme.

I fixed up the hamburger menu to work as expected on click and cleaned up the menu items. One thing that we discovered here was that if someone were to change the menu options on the monolith, those changes would not propagate to zendesk. So we’ll need to be cognizant if a new feature is developed and added to the monolith, it will be necessary to manually add it to zendesk as well. In order to keep things cleaner, we removed a submenu options from the panel as well. 

I listed in the readme instructions on the recommended workflow for future edits to the zendesk theme. We’ll be leveraging Github integration to keep all changes in source control and avoid using their online editor to make changes. Anytime you need to propagate changes, you can just click ‘Update from Github’ on the theme to make them live. 